### PR TITLE
added OTC paragraph to quickbitcoin

### DIFF
--- a/data/services.yaml
+++ b/data/services.yaml
@@ -1,3 +1,20 @@
+quickbitcoin:
+  label: QuickBitcoin
+  countries: [uk]
+  location: [uk]
+  icon: /favicon.png
+  url: https://quickbitcoin.co.uk/
+  content: |
+     <p>Fastest way to buy bitcoins in the uk:
+        <ul>
+          <li>Average transaction time is under 10 minutes.</li>
+          <li>Pay by UK bank transfer</li>
+        </ul>
+     </p>
+     <p>For large trades contact us at info@quickbitcoin.co.uk. Blocks of 50btc or more can be traded quickly.
+     </p>
+  coins: [btc]
+
 Yacuna:
   label: Yacuna
   countries: [AE, AF, AG, AI, AL, AM, AN, AO, AQ, AR, AS, AT, AU, AW, AX, AZ, BA, BB, BD, BE, BF, BG BH, BI, BJ, BL, BM, BN, BO, BR, BS, BT, BV, BW, BY, CC, CD, CF, CG, CH, CI, CK, CL CM, CN, CO, CR, CU, CV, CX, CY, CZ, DE, DO, DJ, DK, DM, DZ, EC, EE, EG, EH, ER, ES, ET, FI FJ, FK, FM, FO, FR, GA, GD, GE, GF, GG, GH, GI, GL, GM, GN, GP, GQ, GR, GS, GT, GU, GW, GY HK, HM, HN, HR, HT, HU, ID, IE, IN, IL, IM, IO, IQ, IS, IT, JE, JM, JO, JP, KE, KG, KH KI, KM, KN, KR, KW, KY, KZ, LA, LB, LC, LI, LK, LR, LS, LT, LU, LV, LY, MA, MC, MD, ME MF, MG, MH, MK, ML, MM, MN, MO, MP, MQ, MR, MS, MT, MU, MV, MW, MX, MY, MZ, NA, NC, NE, NF NG, NI, NL, NO, NP, NR, NU, NZ, OM, PA, PE, PF, PG, PH, PK, PL, PM, PN, PR, PS, PT, PW, PY QA, RE, RO, RS, RU, RW, SA, SB, SC, SD, SE, SG, SH, SI, SJ, SK, SL, SM, SN, SO, SR, ST, SV SY, SZ, TC, TD, TF, TG, TH, TJ, TK, TL, TM, TN, TO, TR, TT, TV, TW, TZ, UG, UK, UM, UY, UZ, VA, VC, VE, VG, VI, VN, VU, WF, WS, YE, YT, ZA, ZM, ZW] 
@@ -36,21 +53,6 @@ bittybot:
   url: http://bittybot.co.uk
   content: Buy Bitcoins in the UK for the Best Prices with BittyBot - the UK's No.1 Bitcoin Price Comparison Website
   coins: [BTC]
-
-quickbitcoin:
-  label: QuickBitcoin
-  countries: [uk]
-  location: [uk]
-  icon: /favicon.png
-  url: https://quickbitcoin.co.uk/
-  content: |
-     <p>Fastest way to buy bitcoins in the uk:
-        <ul>
-          <li>Average transaction time is under 10 minutes.</li>
-          <li>Pay by UK bank transfer</li>
-        </ul>
-      </p>
-  coins: [btc]
 
 cointrader:
   label: Cointrader.net


### PR DESCRIPTION
Added OTC paragraph to quickbitcoin

<p>For large trades contact us at info@quickbitcoin.co.uk. Blocks of 50btc or more can be traded quickly.
     </p>