### PR TITLE
Coinsetter addition

### DIFF
--- a/data/services.yaml
+++ b/data/services.yaml
@@ -1,3 +1,11 @@
+Coinsetter:
+  label: Coinsetter
+  countries: [AE, AF, AG, AI, AL, AM, AN, AO, AQ, AR, AS, AT, AU, AW, AX, AZ, BA, BB, BD, BE, BF, BG BH, BI, BJ, BL, BM, BN, BO, BR, BS, BT, BV, BW, BY, CC, CF, CG, CH, CK, CL CM, CN, CO, CR, CV, CX, CY, CZ, DE, DO, DJ, DK, DM, DZ, EC, EE, EG, EH, ER, ES, ET, FI FJ, FK, FM, FO, FR, GA, GD, GE, GF, GG, GH, GI, GL, GM, GN, GP, GQ, GR, GS, GT, GU, GW, GY HK, HM, HN, HR, HT, HU, ID, IE, IN, IL, IM, IO, IS, IT, JE, JM, JO, JP, KE, KG, KH KI, KM, KN, KR, KW, KY, KZ, LA, LC, LI, LK, LS, LT, LU, LV, MA, MC, MD, ME MF, MG, MH, MK, ML, MN, MO, MP, MQ, MR, MS, MT, MU, MV, MW, MX, MY, MZ, NA, NC, NE, NF NG, NI, NL, NO, NP, NR, NU, NZ, OM, PA, PE, PF, PG, PH, PK, PL, PM, PN, PR, PS, PT, PW, PY QA, RE, RO, RS, RU, RW, SA, SB, SC, SE, SG, SH, SI, SJ, SK, SL, SM, SN, SR, ST, SV, SZ, TC, TD, TF, TG, TH, TJ, TK, TL, TM, TN, TO, TR, TT, TV, TW, TZ, UG, UK, UM, UY, UZ, VA, VC, VE, VG, VI, VN, VU, WF, WS, YT, ZA, ZM, ZW] 
+  icon: https://www.coinsetter.com/resources/favicon.ico
+  url: https://www.coinsetter.com/
+  content: Coinsetter Wall Street's most popular bitcoin exchange for firms and individuals. Our platform puts the power of institutional bitcoin trading at your fingertips.
+  coins: [btc]
+
 Yacuna:
   label: Yacuna
   countries: [AE, AF, AG, AI, AL, AM, AN, AO, AQ, AR, AS, AT, AU, AW, AX, AZ, BA, BB, BD, BE, BF, BG BH, BI, BJ, BL, BM, BN, BO, BR, BS, BT, BV, BW, BY, CC, CD, CF, CG, CH, CI, CK, CL CM, CN, CO, CR, CU, CV, CX, CY, CZ, DE, DO, DJ, DK, DM, DZ, EC, EE, EG, EH, ER, ES, ET, FI FJ, FK, FM, FO, FR, GA, GD, GE, GF, GG, GH, GI, GL, GM, GN, GP, GQ, GR, GS, GT, GU, GW, GY HK, HM, HN, HR, HT, HU, ID, IE, IN, IL, IM, IO, IQ, IS, IT, JE, JM, JO, JP, KE, KG, KH KI, KM, KN, KR, KW, KY, KZ, LA, LB, LC, LI, LK, LR, LS, LT, LU, LV, LY, MA, MC, MD, ME MF, MG, MH, MK, ML, MM, MN, MO, MP, MQ, MR, MS, MT, MU, MV, MW, MX, MY, MZ, NA, NC, NE, NF NG, NI, NL, NO, NP, NR, NU, NZ, OM, PA, PE, PF, PG, PH, PK, PL, PM, PN, PR, PS, PT, PW, PY QA, RE, RO, RS, RU, RW, SA, SB, SC, SD, SE, SG, SH, SI, SJ, SK, SL, SM, SN, SO, SR, ST, SV SY, SZ, TC, TD, TF, TG, TH, TJ, TK, TL, TM, TN, TO, TR, TT, TV, TW, TZ, UG, UK, UM, UY, UZ, VA, VC, VE, VG, VI, VN, VU, WF, WS, YE, YT, ZA, ZM, ZW] 


### PR DESCRIPTION
This update adds New York City-based bitcoin exchange Coinsetter to the site.